### PR TITLE
Replaced use of frames for layout with autolayout anchors.

### DIFF
--- a/DecimalMinusTextField.swift
+++ b/DecimalMinusTextField.swift
@@ -34,7 +34,7 @@ class DecimalMinusTextField: UITextField {
         let doneButton = UIButton(type: UIButtonType.custom)
         minusButton.setTitle("-", for: UIControlState())
         doneButton.setTitle("Done", for: UIControlState())
-        let buttonWidth = view.frame.size.width/3;
+        let buttonWidth = view.frame.size.width/3
         
         view.addSubview(minusButton)
         view.addSubview(doneButton)
@@ -56,7 +56,7 @@ class DecimalMinusTextField: UITextField {
         minusButton.addTarget(self, action: #selector(DecimalMinusTextField.minusTouchUpInside(_:)), for: UIControlEvents.touchUpInside)
         doneButton.addTarget(self, action: #selector(DecimalMinusTextField.doneTouchUpInside(_:)), for: UIControlEvents.touchUpInside)
         
-        return view;
+        return view
     }
     
     @objc func minusTouchUpInside(_ sender: UIButton!) {
@@ -74,7 +74,7 @@ class DecimalMinusTextField: UITextField {
     }
     
     @objc func doneTouchUpInside(_ sender: UIButton!) {
-        self.resignFirstResponder();
+        self.resignFirstResponder()
         
     }
     

--- a/DecimalMinusTextField.swift
+++ b/DecimalMinusTextField.swift
@@ -35,14 +35,26 @@ class DecimalMinusTextField: UITextField {
         minusButton.setTitle("-", for: UIControlState())
         doneButton.setTitle("Done", for: UIControlState())
         let buttonWidth = view.frame.size.width/3;
-        minusButton.frame = CGRect(x: 0, y: 0, width: buttonWidth, height: 44);
-        doneButton.frame = CGRect(x: view.frame.size.width - buttonWidth, y: 0, width: buttonWidth, height: 44);
-        
-        minusButton.addTarget(self, action: #selector(DecimalMinusTextField.minusTouchUpInside(_:)), for: UIControlEvents.touchUpInside)
-        doneButton.addTarget(self, action: #selector(DecimalMinusTextField.doneTouchUpInside(_:)), for: UIControlEvents.touchUpInside)
         
         view.addSubview(minusButton)
         view.addSubview(doneButton)
+        
+        minusButton.translatesAutoresizingMaskIntoConstraints = false
+        minusButton.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        minusButton.widthAnchor.constraint(equalToConstant: buttonWidth).isActive = true
+        minusButton.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        minusButton.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        minusButton.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+        doneButton.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        doneButton.widthAnchor.constraint(equalToConstant: buttonWidth).isActive = true
+        doneButton.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        doneButton.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        doneButton.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        
+        minusButton.addTarget(self, action: #selector(DecimalMinusTextField.minusTouchUpInside(_:)), for: UIControlEvents.touchUpInside)
+        doneButton.addTarget(self, action: #selector(DecimalMinusTextField.doneTouchUpInside(_:)), for: UIControlEvents.touchUpInside)
         
         return view;
     }
@@ -70,6 +82,4 @@ class DecimalMinusTextField: UITextField {
         super.layoutSubviews()
         self.inputAccessoryView = getAccessoryButtons()
     }
-
-
 }


### PR DESCRIPTION
This helps avoid layout issues like this:
<img width="529" alt="screenshot 2018-09-30 at 17 46 22" src="https://user-images.githubusercontent.com/422196/46260102-f1e40500-c4d9-11e8-8868-0a7b066dcea3.png">

And should help keep it consistently like this:
<img width="531" alt="screenshot 2018-09-30 at 17 55 19" src="https://user-images.githubusercontent.com/422196/46260108-01fbe480-c4da-11e8-936c-09c8f988f4e2.png">
